### PR TITLE
Create copy-release.yml

### DIFF
--- a/.github/workflows/copy-release.yml
+++ b/.github/workflows/copy-release.yml
@@ -1,0 +1,81 @@
+name: Copy Existing Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to copy (e.g., v1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  copy-release:
+    name: Copy Release to Public Repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download release assets
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const tagName = '${{ inputs.tag_name }}';
+            
+            // Get the specified release
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag: tagName
+            });
+            
+            console.log(`Found release: ${release.tag_name}`);
+            console.log(`Assets found: ${release.assets.length}`);
+            
+            // Download all assets
+            for (const asset of release.assets) {
+              console.log(`Downloading ${asset.name}...`);
+              const response = await github.rest.repos.getReleaseAsset({
+                owner,
+                repo,
+                asset_id: asset.id,
+                headers: {
+                  Accept: 'application/octet-stream'
+                }
+              });
+              
+              fs.writeFileSync(asset.name, Buffer.from(response.data));
+              console.log(`Downloaded ${asset.name} (${asset.size} bytes)`);
+            }
+
+      - name: Create Release in Public Repository
+        uses: softprops/action-gh-release@v2
+        with:
+          repository: joseph-abdallah04/Scopix
+          tag_name: ${{ inputs.tag_name }}
+          name: Release ${{ inputs.tag_name }}
+          body: |
+            ## Scopix Desktop Application - ${{ inputs.tag_name }}
+            
+            **For speech pathologists and medical professionals researching Inducible Laryngeal Obstruction (ILO)**
+            
+            ### Downloads Available:
+            - **Windows**: `.exe` installer
+            - **Linux**: `.AppImage` portable application
+            - **macOS**: `.dmg` installer (if available)
+            
+            ### Before Installing:
+            1. **Review the [End User License Agreement (EULA)](https://github.com/joseph-abdallah04/Scopix/blob/main/EULA.md)**
+            2. **Read the [README](https://github.com/joseph-abdallah04/Scopix/blob/main/README.md)** for installation instructions
+            3. **Check system requirements** in the README
+            
+            By downloading and using Scopix, you agree to the terms outlined in the EULA.
+            
+            ### Medical Disclaimer
+            Scopix is intended as a tool for research and professional use by qualified medical practitioners. It is **not** a substitute for professional medical judgment, diagnosis, or treatment.
+          files: |
+            *.dmg
+            *.exe
+            *.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate copying an existing release (and its assets) from the current repository to a public repository. This workflow streamlines the process of distributing releases to external users, ensuring consistency and saving manual effort.

**New GitHub Actions workflow for release copying:**

* Added `.github/workflows/copy-release.yml` to define a workflow that, when triggered manually, downloads release assets for a specified tag and creates a release with those assets in the public repository `joseph-abdallah04/Scopix`.
* The workflow includes detailed release notes, download links for different operating systems, and legal/disclaimer information in the release body.